### PR TITLE
Add sticky note delete option

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -109,6 +109,14 @@
     cursor: pointer;
 }
 
+.context-menu-item.delete {
+    color: #d32f2f;
+}
+
+.context-menu-item.delete:hover {
+    background-color: #ffcdd2;
+}
+
 .context-menu-item:hover {
     background-color: #f0f0f0;
     border-radius: 4px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,16 @@ function App() {
     setContextMenuState(contextMenuStateData)
   }
 
+  const handleDeleteClick = () => {
+    if (contextMenuState.noteId === null) return
+
+    setStickyNotes(notes =>
+      notes.filter(note => note.id !== contextMenuState.noteId)
+    )
+
+    setContextMenuState(contextMenuStateData)
+  }
+
   const handleEditSaveClick = () => {
     if (editState.noteId === null) return
 
@@ -257,6 +267,12 @@ function App() {
                 onClick={handleEditClick}
               >
                 Edit
+              </div>
+              <div
+                className="context-menu-item delete"
+                onClick={handleDeleteClick}
+              >
+                Delete
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- allow deleting notes via context menu
- style delete menu item

## Testing
- `npm run lint`
- `bash spellcheck.sh` *(fails: cspell not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e6cc8f9988330a9dea90f8503e798