### PR TITLE
Add delete option to sticky notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Board markdown
 
 ![image](images/20250722.png)
 
+Right-click a sticky note to edit or delete it.
+
 > [!NOTE]
 > Although the title says "Markdown", the initial data is managed in JSON. 🥺
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,12 @@ function App() {
     setContextMenuState(contextMenuStateData)
   }
 
+  const handleDeleteClick = () => {
+    if (contextMenuState.noteId === null) return
+    setStickyNotes(notes => notes.filter(note => note.id !== contextMenuState.noteId))
+    setContextMenuState(contextMenuStateData)
+  }
+
   const handleEditSaveClick = () => {
     if (editState.noteId === null) return
 
@@ -257,6 +263,12 @@ function App() {
                 onClick={handleEditClick}
               >
                 Edit
+              </div>
+              <div
+                className="context-menu-item"
+                onClick={handleDeleteClick}
+              >
+                Delete
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- allow deleting sticky notes through the context menu
- document how to edit or delete a note

## Testing
- `npx eslint .`
- `bash spellcheck.sh` *(fails: `cspell: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687e6d9a42588330b338c49bf756290c